### PR TITLE
eval-type-backport 0.2.2 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+upload_channels:
+  - sfe1ed40
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,34 @@
+{% set name = "eval-type-backport" %}
+{% set version = "0.2.2" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz"
+  sha256: f0576b4cf01ebb5bd358d02314d31846af5e07678387486e2c798af0e7d849c1
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+
+about:
+  home: https://github.com/alexmojaki/eval_type_backport/
+  license: MIT
+  license_family: MIT
+  license_file: 
+  summary: This is a tiny package providing a replacement for typing._eval_type to support newer typing features in older Python versions.
+  doc_url: https://github.com/alexmojaki/eval_type_backport/
+  dev_url: https://github.com/alexmojaki/eval_type_backport/
+
+extra:
+  recipe-maintainers:
+    - solesnake

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,15 +17,26 @@ requirements:
   host:
     - pip
     - python
+    - wheel
   run:
     - python
+
+test:
+  imports:
+    - eval-type-backport
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/alexmojaki/eval_type_backport/
   license: MIT
   license_family: MIT
-  license_file: 
-  summary: This is a tiny package providing a replacement for typing._eval_type to support newer typing features in older Python versions.
+  license_file: LICENSE
+  summary: Like `typing._eval_type`, but lets older Python versions use newer typing features.
+  description:  |
+    This is a tiny package providing a replacement for typing._eval_type to support newer typing features in older Python versions.
   doc_url: https://github.com/alexmojaki/eval_type_backport/
   dev_url: https://github.com/alexmojaki/eval_type_backport/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ test:
 about:
   home: https://github.com/alexmojaki/eval_type_backport/
   license: MIT
+  license_file: LICENSE
   license_family: MIT
   summary: Like `typing._eval_type`, but lets older Python versions use newer typing features.
   description:  |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
 
 test:
   imports:
-    - eval-type-backport
+    - eval_type_backport
   commands:
     - pip check
   requires:
@@ -33,7 +33,6 @@ about:
   home: https://github.com/alexmojaki/eval_type_backport/
   license: MIT
   license_family: MIT
-  license_file: LICENSE
   summary: Like `typing._eval_type`, but lets older Python versions use newer typing features.
   description:  |
     This is a tiny package providing a replacement for typing._eval_type to support newer typing features in older Python versions.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,17 +17,23 @@ requirements:
   host:
     - pip
     - python
+    - setuptools
+    - setuptools-scm
     - wheel
   run:
     - python
 
 test:
+  source_files:
+    - tests
   imports:
     - eval_type_backport
   commands:
     - pip check
+    - pytest tests -v
   requires:
     - pip
+    - pytest
 
 about:
   home: https://github.com/alexmojaki/eval_type_backport/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
 about:
   home: https://github.com/alexmojaki/eval_type_backport/
   license: MIT
-  license_file: LICENSE
+  license_url: https://github.com/alexmojaki/eval_type_backport/blob/main/LICENSE.txt
   license_family: MIT
   summary: Like `typing._eval_type`, but lets older Python versions use newer typing features.
   description:  |


### PR DESCRIPTION
eval-type-backport 0.2.2 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-6846]
- dev_url:        https://github.com/alexmojaki/eval_type_backport/tree/v0.2.2
- conda_forge:    None
- pypi:           https://pypi.org/project/eval-type-backport/0.2.2
- pypi inspector: https://inspector.pypi.io/project/eval-type-backport/0.2.2

### Explanation of changes:

- new version number


[PKG-6846]: https://anaconda.atlassian.net/browse/PKG-6846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ